### PR TITLE
Vale981 localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The `connect` event will fire only once when the initial ssh connection is made.
 - `kill` - a method to kill autossh
 - `pid` - the autossh process id
 - `host`
+- `localHost` - The host, to which the tunnel applies.
 - `username`
 - `remotePort`
 - `localPort`
@@ -126,6 +127,25 @@ autossh({
 ```
 
 <br />
+
+#### Tunneling Ports from another Host
+
+It is also possible to use the tunnel as gateway to another host in the local network (for example a webcam).
+
+By default, the `localHost` property is set to `localhost`, but you can overwrite it.
+
+``` javascript
+autossh({
+  host: '111.22.333.444',
+  localhost: '192.168.1.25',
+  username: 'root',
+  localPort: '64444',
+  remotePort: 5432
+})
+.on('connect', connection => {
+  console.log('connected: ', connection);
+});
+```
 
 #### Killing the Autossh Process
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ It is also possible to use the tunnel as gateway to another host in the local ne
 
 By default, the `localHost` property is set to `localhost`, but you can overwrite it.
 
+**Note that setting this property to a value different from `localhost` will make the tunnel reverse automaticly.**
+
 ``` javascript
 autossh({
   host: '111.22.333.444',

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The `connect` event will fire only once when the initial ssh connection is made.
 - `kill` - a method to kill autossh
 - `pid` - the autossh process id
 - `host`
+- `localHost` - The host, to which the tunnel applies.
 - `username`
 - `remotePort`
 - `localPort`
@@ -126,6 +127,27 @@ autossh({
 ```
 
 <br />
+
+#### Tunneling Ports from another Host
+
+It is also possible to use the tunnel as gateway to another host in the local network (for example a webcam).
+
+By default, the `localHost` property is set to `localhost`, but you can overwrite it.
+
+``` javascript
+autossh({
+  host: '111.22.333.444',
+  localhost: '192.168.1.25',
+  username: 'root',
+  localPort: '64444',
+  remotePort: 5432
+})
+.on('connect', connection => {
+  console.log('connected: ', connection);
+});
+```
+
+
 
 #### Killing the Autossh Process
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -22,19 +22,17 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 /* AutoSSH class
 */
-
 var AutoSSH = function (_EventEmitter) {
   _inherits(AutoSSH, _EventEmitter);
 
   /*
   */
-
   function AutoSSH() {
-    var conf = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+    var conf = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
     _classCallCheck(this, AutoSSH);
 
-    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(AutoSSH).call(this));
+    var _this = _possibleConstructorReturn(this, (AutoSSH.__proto__ || Object.getPrototypeOf(AutoSSH)).call(this));
 
     _this.configure(conf);
 
@@ -57,9 +55,11 @@ var AutoSSH = function (_EventEmitter) {
   _createClass(AutoSSH, [{
     key: 'configure',
     value: function configure(conf) {
-      this.reverse = conf.reverse === true || false;
-
       this.host = conf.host;
+      this.localHost = conf.localHost || 'localhost';
+
+      this.reverse = conf.reverse === true || this.localHost !== 'localhost';
+
       this.username = conf.username || 'root';
       this.remotePort = conf.remotePort;
 
@@ -86,7 +86,7 @@ var AutoSSH = function (_EventEmitter) {
       var _this2 = this;
 
       var port = this.localPort === 'auto' ? this.generateRandomPort() : this.localPort;
-      if (this.reverse) {
+      if (this.reverse || this.localHost !== 'localhost') {
         this.execTunnel(function () {
           _this2.pollConnection();
         });
@@ -119,6 +119,7 @@ var AutoSSH = function (_EventEmitter) {
         },
         pid: null,
         host: this.host || null,
+        localHost: this.localHost || null,
         username: this.username || null,
         remotePort: parseInt(this.remotePort),
         localPort: parseInt(this.localPort),
@@ -195,11 +196,18 @@ var AutoSSH = function (_EventEmitter) {
     value: function isConnectionEstablished(connEstablishedCb) {
       var _this6 = this;
 
+      if (this.localHost !== 'localhost') {
+        connEstablishedCb(true);
+        return;
+      }
+
       _portfinder2.default.getPort({ port: this.localPort }, function (portfinderErr, freePort) {
         if (portfinderErr) return connEstablishedCb(false);
 
         if (_this6.localPort === freePort) return connEstablishedCb(false);else return connEstablishedCb(true);
       });
+
+      return;
     }
 
     /* parses the conf for errors
@@ -274,8 +282,9 @@ var AutoSSH = function (_EventEmitter) {
       var defaultOpts = this.generateDefaultOptions();
       var privateKey = this.privateKey ? '-i ' + this.privateKey : '';
       var sshPort = this.sshPort === 22 ? '' : '-p ' + this.sshPort;
+      var gatewayPorts = this.localHost === 'localhost' ? '' : '-o GatewayPorts=yes';
 
-      return defaultOpts + ' ' + serverAliveOpts + ' ' + privateKey + ' ' + sshPort;
+      return defaultOpts + ' ' + serverAliveOpts + ' ' + gatewayPorts + ' ' + privateKey + ' ' + sshPort;
     }
 
     /*
@@ -286,7 +295,7 @@ var AutoSSH = function (_EventEmitter) {
     value: function generateExecString() {
       var startPort = this.reverse ? this.remotePort : this.localPort;
       var endPort = this.reverse ? this.localPort : this.remotePort;
-      var bindAddress = startPort + ':localhost:' + endPort;
+      var bindAddress = startPort + ':' + this.localHost + ':' + endPort;
       var options = this.generateExecOptions();
       var userAtHost = this.username + '@' + this.host;
       var method = this.reverse ? 'R' : 'L';

--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ var AutoSSH = function (_EventEmitter) {
     value: function configure(conf) {
       this.host = conf.host;
       this.localHost = conf.localHost || 'localhost';
-
       this.reverse = conf.reverse === true || this.localHost !== 'localhost';
 
       this.username = conf.username || 'root';
@@ -196,7 +195,7 @@ var AutoSSH = function (_EventEmitter) {
     value: function isConnectionEstablished(connEstablishedCb) {
       var _this6 = this;
 
-      if (this.localHost !== 'localhost') {
+      if (this.localHost !== 'localhost' || this.reverse) {
         connEstablishedCb(true);
         return;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ class AutoSSH extends EventEmitter {
     this.reverse = conf.reverse === true || false;
 
     this.host = conf.host;
+    this.localhost = conf.localHost || 'localhost';
     this.username = conf.username || 'root';
     this.remotePort = conf.remotePort;
 
@@ -87,6 +88,7 @@ class AutoSSH extends EventEmitter {
       kill: () => this.kill,
       pid: null,
       host: this.host || null,
+      localHost: this.localHost || null,
       username: this.username || null,
       remotePort: parseInt(this.remotePort),
       localPort: parseInt(this.localPort),
@@ -245,7 +247,7 @@ class AutoSSH extends EventEmitter {
   generateExecString() {
     const startPort = this.reverse ? this.remotePort : this.localPort;
     const endPort = this.reverse ? this.localPort : this.remotePort;
-    const bindAddress = `${startPort}:localhost:${endPort}`;
+    const bindAddress = `${startPort}:${this.localHost}:${endPort}`;
     const options = this.generateExecOptions();
     const userAtHost = `${this.username}@${this.host}`;
     const method = this.reverse ? 'R' : 'L';

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,6 @@ class AutoSSH extends EventEmitter {
   configure(conf) {
     this.host = conf.host;
     this.localHost = conf.localHost || 'localhost';
-
     this.reverse = conf.reverse === true || (this.localHost !== 'localhost');
 
     this.username = conf.username || 'root';
@@ -153,7 +152,7 @@ class AutoSSH extends EventEmitter {
   /* checks if connection is established at port
   */
   isConnectionEstablished(connEstablishedCb) {
-    if (this.localHost !== 'localhost') {
+    if (this.localHost !== 'localhost' || this.reverse) {
       connEstablishedCb(true);
       return;
     }


### PR DESCRIPTION
Added an option to specify a different local host.
This, for instance, enables forwarding traffic from the local network.

Things like `ssh -R xxxx:192.168.1.12:xxxx` work now.