### PR TITLE
allow reverse: false to override automatic reversal by localHost

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ var AutoSSH = function (_EventEmitter) {
     value: function configure(conf) {
       this.host = conf.host;
       this.localHost = conf.localHost || 'localhost';
-      this.reverse = conf.reverse === true || this.localHost !== 'localhost';
+      this.reverse = conf.reverse === true || this.localHost !== 'localhost' && conf.reverse !== false;
 
       this.username = conf.username || 'root';
       this.remotePort = conf.remotePort;

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,9 @@ class AutoSSH extends EventEmitter {
   configure(conf) {
     this.host = conf.host;
     this.localHost = conf.localHost || 'localhost';
-    this.reverse = conf.reverse === true || (this.localHost !== 'localhost');
+    this.reverse = conf.reverse === true || (
+      this.localHost !== 'localhost' && conf.reverse !== false
+    );
 
     this.username = conf.username || 'root';
     this.remotePort = conf.remotePort;


### PR DESCRIPTION
# Allow reverse: false when localHost is set.

There are use cases where -L port:someOtherHost:port is needed.

This PR adds the ability to override the automatic reversal setting by explicitly declaring `reverse: false`.  

Should be backward compatible as the original behavior is not changed.
